### PR TITLE
docs(README): change openui5_theme default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,16 @@ Options for the [less](http://lesscss.org) compiler (`tree.toCss`).
 ```js
 grunt.initConfig({
   openui5_theme: {
-    options: {},
-    files: [
-      {
-        expand: true,
-        cwd: 'lib1',
-        src: 'my/ui/lib/themes/foo/library.source.less',
-        dest: 'tmp'
-      }
-    ]
+    library: {
+      files: [
+        {
+          expand: true,
+          cwd: 'lib1',
+          src: 'my/ui/lib/themes/foo/library.source.less',
+          dest: 'tmp'
+        }
+      ]
+    }
   },
 });
 ```
@@ -96,14 +97,16 @@ grunt.initConfig({
         compress: true
       }
     },
-    files: [
-      {
-        expand: true,
-        cwd: 'lib2',
-        src: 'my/ui/lib/themes/bar/library.source.less',
-        dest: 'tmp'
-      }
-    ]
+    library: {
+      files: [
+        {
+          expand: true,
+          cwd: 'lib2',
+          src: 'my/ui/lib/themes/bar/library.source.less',
+          dest: 'tmp'
+        }
+      ]
+    }
   },
 });
 ```


### PR DESCRIPTION
openui5_theme is a multitask. Trying to run it without defining any task (`library` in my example) will cause Grunt to interpret `files` as task name and fail with `Warning: pattern.indexOf is not a function Use --force to continue. Aborted due to warnings. Process finished with exit code 3`. Wrapping `files` configuration to `library` task solves the issue.