### PR TITLE
fail gracefully when minification fails

### DIFF
--- a/tasks/preload.js
+++ b/tasks/preload.js
@@ -199,7 +199,7 @@ module.exports = function (grunt) {
 						var fileName = resourceMap[preloadFile].fullPath;
 						var fileContent = grunt.file.read(fileName);
 						var fileExtension = path.extname(fileName);
-						
+
 						var iOriginalSize, iCompressedSize;
 
 						if (options.compress) {
@@ -207,30 +207,34 @@ module.exports = function (grunt) {
 							iOriginalSize = fileContent.length;
 							iPreloadOriginalSize += iOriginalSize;
 
-							switch (fileExtension) {
-							case '.js':
-								// Javascript files are processed by Uglify
-								fileContent = uglify.minify(fileContent, {
-									fromString: true,
-									warnings: grunt.option('verbose') === true,
-									output: {
-										comments: copyrightCommentsPattern
+							try {
+								switch (fileExtension) {
+								case '.js':
+									// Javascript files are processed by Uglify
+									fileContent = uglify.minify(fileContent, {
+										fromString: true,
+										warnings: grunt.option('verbose') === true,
+										output: {
+											comments: copyrightCommentsPattern
+										}
+									}).code;
+									break;
+								case '.json':
+									// JSON is parsed and written to string again to remove unwanted white space
+									fileContent = JSON.stringify(JSON.parse(fileContent));
+									break;
+								case '.xml':
+									// For XML we use the pretty data
+
+									// Do not minify if XML(View) contains an <*:pre> tag because whitespace of HTML <pre> should be preserved (should only happen rarely)
+									if (!xmlHtmlPrePattern.test(fileContent)) {
+										fileContent = pd.xmlmin(fileContent, false);
 									}
-								}).code;
-								break;
-							case '.json':
-								// JSON is parsed and written to string again to remove unwanted white space
-								fileContent = JSON.stringify(JSON.parse(fileContent));
-								break;
-							case '.xml':
-								// For XML we use the pretty data
 
-								// Do not minify if XML(View) contains an <*:pre> tag because whitespace of HTML <pre> should be preserved (should only happen rarely)
-								if (!xmlHtmlPrePattern.test(fileContent)) {
-									fileContent = pd.xmlmin(fileContent, false);
+									break;
 								}
-
-								break;
+							} catch (e) {
+								grunt.fail.warn('Failed to minify ' + fileName + '. This might be due to a syntax error in the file.');
 							}
 
 							iCompressedSize = fileContent.length;


### PR DESCRIPTION
This PR contains a fix for #36.

It simply wraps the minfication logic for JS, JSON, and XML into a try-catch block and then terminates with a grunt error message.

I found it difficult to add unit tests for this change with the way tests are currently written for the preload task. As this change doesn't really add or change features, I would take the fact that the existing tests still run as a good enough proof of the correctness of the change.

What do you think?