### PR TITLE
Add ascii_only parameter to minification procedure

### DIFF
--- a/tasks/preload.js
+++ b/tasks/preload.js
@@ -214,7 +214,8 @@ module.exports = function (grunt) {
 									fromString: true,
 									warnings: grunt.option('verbose') === true,
 									output: {
-										comments: copyrightCommentsPattern
+										comments: copyrightCommentsPattern,
+										ascii_only: true
 									}
 								}).code;
 								break;


### PR DESCRIPTION
As per #39 UglifyJS breaks escape sequences for national symbols. This property tells the library to escape Unicode symbols.