### PR TITLE
 tranform resource path from folder into module

### DIFF
--- a/.che/project.json
+++ b/.che/project.json
@@ -1,0 +1,1 @@
+{"type":"sap.web","builders":{"configs":{}},"runners":{"configs":{}},"attributes":{"sap.watt.common.setting":["{\"projectType\":[\"sap.watt.uitools.ide.web\",\"sap.watt.uitools.ide.fiori\"]}"]},"mixinTypes":[]}

--- a/tasks/preload.js
+++ b/tasks/preload.js
@@ -290,7 +290,9 @@ module.exports = function (grunt) {
 							grunt.verbose.writeln(log);
 						}
 
-						preloadObject.modules[preloadFile] = fileContent;
+						// tranform resource path from folder into module
+						// my.lib into my/lib
+						preloadObject.modules[preloadFile.replace(/[.](?=.*[.])/, '/')] = fileContent;
 					});
 
 					var content = JSON.stringify(preloadObject, null, '\t');


### PR DESCRIPTION
Dear developers,

This is the suggestion I want to suggest to fix the problem when we use repository/folder with dots for UI5 library.

After this we'll  be able to solve the problem when sap.ovp namespace is not trasferred to sap/ovp module in library-preload.json file.

Thanks!