### PR TITLE
Fix documentation of compatVersion option

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Default:
 
 Glob pattern(s) for finding relevant resources inside `cwd`. If set, the default patterns will be replaced.
 
-##### compatVersion
+#### compatVersion
 Type: `string`  
 Default: `edge`
 


### PR DESCRIPTION
Indentation should be on 'options' level instead of 'resources'

Resolves #67