### PR TITLE
[FEATURE] preload: ES6+ support for uglifying JS Files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,13 +190,13 @@ Default value: `true`
 Optional parameter to set compression/minification of the files or to provide
 additional options.
 
-- JavaScript is minified using [UglifyJS2](https://github.com/mishoo/UglifyJS2)
+- JavaScript is minified using [UglifyJS v3 (`uglify-es`)](https://github.com/mishoo/UglifyJS2/tree/harmony)
 - XML is minified using [pretty-data](https://github.com/vkiryukhin/pretty-data)
 - JSON is parsed for correctness and to remove extra whitespace
 
 An `object` can be used to provide options.  
 Currrently only `uglifyjs` is supported.  
-The given object will be passed to `UglifyJS2.minify` (see [here](https://github.com/mishoo/UglifyJS2#api-reference) for  options) and merged with the defaults (see below).  
+The given object will be passed to `minify` (see [here](https://github.com/mishoo/UglifyJS2/tree/harmony#output-options) for options) and merged with the defaults (see below).  
 
 ```js
 compress: {
@@ -207,7 +207,7 @@ compress: {
   }
 }
 ```
-Note that `fromString` and `warnings` will be always overridden.
+Note that `warnings` will be always overridden depending on the Grunt ["verbose" option](https://gruntjs.com/using-the-cli#verbose-v).
 
 #### components
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,16 +59,6 @@
       "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
       "dev": true
     },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
-      }
-    },
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -272,15 +262,6 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "optional": true
     },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
-      }
-    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -328,16 +309,6 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
-    },
-    "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
-        "wordwrap": "0.0.2"
-      }
     },
     "clone": {
       "version": "2.1.1",
@@ -548,7 +519,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1580,11 +1552,6 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
@@ -1765,19 +1732,6 @@
         }
       }
     },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "requires": {
-        "is-buffer": "1.1.6"
-      }
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
-    },
     "less": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/less/-/less-1.6.3.tgz",
@@ -1828,11 +1782,6 @@
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
-    },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -2360,11 +2309,6 @@
         "strip-indent": "1.0.1"
       }
     },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-    },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
@@ -2444,14 +2388,6 @@
       "requires": {
         "onetime": "2.0.1",
         "signal-exit": "3.0.2"
-      }
-    },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "requires": {
-        "align-text": "0.1.4"
       }
     },
     "rimraf": {
@@ -2988,28 +2924,26 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+    "uglify-es": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "commander": "2.13.0",
+        "source-map": "0.6.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+        },
         "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "optional": true
     },
     "underscore.string": {
       "version": "3.3.4",
@@ -3098,16 +3032,6 @@
         "isexe": "2.0.0"
       }
     },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
-    },
-    "wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -3138,24 +3062,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
-    },
-    "yargs": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
-        "window-size": "0.1.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-        }
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "pretty-data": "^0.40.0",
     "serve-static": "^1.13.2",
     "slash": "^1.0.0",
-    "uglify-js": "^2.8.29",
+    "uglify-es": "^3.3.9",
     "urljoin": "^0.1.5"
   },
   "devDependencies": {

--- a/tasks/preload.js
+++ b/tasks/preload.js
@@ -16,7 +16,7 @@
 
 var path = require('path');
 var slash = require('slash');
-var uglify = require('uglify-js');
+var uglify = require('uglify-es');
 var pd = require('pretty-data').pd;
 var maxmin = require('maxmin');
 
@@ -259,7 +259,6 @@ module.exports = function (grunt) {
 							options.compress.uglifyjs = options.compress.uglifyjs || {};
 
 							// Always override given options, override shouldn't be possible
-							options.compress.uglifyjs.fromString = true;
 							options.compress.uglifyjs.warnings = grunt.option('verbose') === true;
 
 							// Set default "comments" option if not given already

--- a/test/preload/expected/component_compat_140/my/app/Component-preload.js
+++ b/test/preload/expected/component_compat_140/my/app/Component-preload.js
@@ -2,7 +2,7 @@ jQuery.sap.registerPreloadedModules({
 	"version": "2.0",
 	"name": "my/app/Component-preload",
 	"modules": {
-		"my/app/Component.js": "/* © */\n\"use strict\";function myFunction(n,o){return n+o}/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */\nconsole.log(\"myJS\");",
+		"my/app/Component.js": "/* © */\n\"use strict\";\n/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */function myFunction(n,o){return n+o}console.log(\"myJS\");",
 		"my/app/view/my.view.xml": "<my>XML</my>\n",
 		"my/app/view/myHtmlPre.view.xml": "<my>XML</my>\n<!-- A comment in XML is the same as in HTML -->\n<html:pre>   </html:pre>"
 	}

--- a/test/preload/expected/component_compat_154/my/app/Component-preload.js
+++ b/test/preload/expected/component_compat_154/my/app/Component-preload.js
@@ -1,5 +1,5 @@
 sap.ui.require.preload({
-	"my/app/Component.js": "/* © */\n\"use strict\";function myFunction(n,o){return n+o}/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */\nconsole.log(\"myJS\");",
+	"my/app/Component.js": "/* © */\n\"use strict\";\n/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */function myFunction(n,o){return n+o}console.log(\"myJS\");",
 	"my/app/view/my.view.xml": "<my>XML</my>\n",
 	"my/app/view/myHtmlPre.view.xml": "<my>XML</my>\n<!-- A comment in XML is the same as in HTML -->\n<html:pre>   </html:pre>"
 }, "my/app/Component-preload");

--- a/test/preload/expected/component_default_options/my/app/Component-preload.js
+++ b/test/preload/expected/component_default_options/my/app/Component-preload.js
@@ -1,5 +1,5 @@
 sap.ui.require.preload({
-	"my/app/Component.js": "/* © */\n\"use strict\";function myFunction(n,o){return n+o}/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */\nconsole.log(\"myJS\");",
+	"my/app/Component.js": "/* © */\n\"use strict\";\n/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */function myFunction(n,o){return n+o}console.log(\"myJS\");",
 	"my/app/view/my.view.xml": "<my>XML</my>\n",
 	"my/app/view/myHtmlPre.view.xml": "<my>XML</my>\n<!-- A comment in XML is the same as in HTML -->\n<html:pre>   </html:pre>"
 }, "my/app/Component-preload");

--- a/test/preload/expected/component_resource_prefix/Component-preload.js
+++ b/test/preload/expected/component_resource_prefix/Component-preload.js
@@ -1,5 +1,5 @@
 sap.ui.require.preload({
-	"my/app/Component.js": "/* © */\n\"use strict\";function myFunction(n,o){return n+o}/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */\nconsole.log(\"myJS\");",
+	"my/app/Component.js": "/* © */\n\"use strict\";\n/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */function myFunction(n,o){return n+o}console.log(\"myJS\");",
 	"my/app/view/my.view.xml": "<my>XML</my>\n",
 	"my/app/view/myHtmlPre.view.xml": "<my>XML</my>\n<!-- A comment in XML is the same as in HTML -->\n<html:pre>   </html:pre>"
 }, "my/app/Component-preload");

--- a/test/preload/expected/library_compat_138/my/ui/lib/library-preload.json
+++ b/test/preload/expected/library_compat_138/my/ui/lib/library-preload.json
@@ -3,7 +3,7 @@
 	"name": "my.ui.lib.library-preload",
 	"modules": {
 		"my/ui/lib/library.js": "jQuery.sap.require(\"sap.ui.core.library\"),jQuery.sap.declare(\"my.ui.lib.library\"),sap.ui.getCore().initLibrary({name:\"my.ui.lib\",version:\"0.0.0\",dependencies:[\"sap.ui.core\"]});",
-		"my/ui/lib/myJS.js": "/* © */\n\"use strict\";function myFunction(n,o){return n+o}/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */\nconsole.log(\"myJS\");",
+		"my/ui/lib/myJS.js": "/* © */\n\"use strict\";\n/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */function myFunction(n,o){return n+o}console.log(\"myJS\");",
 		"my/ui/lib/my.view.xml": "<my>XML</my>\n",
 		"my/ui/lib/myHtmlPre.view.xml": "<my>XML</my>\n<!-- A comment in XML is the same as in HTML -->\n<html:pre>   </html:pre>",
 		"my/ui/lib/foo.properties": "FOO=BAR\n"

--- a/test/preload/expected/library_compat_140/my/ui/lib/library-preload.js
+++ b/test/preload/expected/library_compat_140/my/ui/lib/library-preload.js
@@ -3,7 +3,7 @@ jQuery.sap.registerPreloadedModules({
 	"name": "my/ui/lib/library-preload",
 	"modules": {
 		"my/ui/lib/library.js": "jQuery.sap.require(\"sap.ui.core.library\"),jQuery.sap.declare(\"my.ui.lib.library\"),sap.ui.getCore().initLibrary({name:\"my.ui.lib\",version:\"0.0.0\",dependencies:[\"sap.ui.core\"]});",
-		"my/ui/lib/myJS.js": "/* © */\n\"use strict\";function myFunction(n,o){return n+o}/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */\nconsole.log(\"myJS\");",
+		"my/ui/lib/myJS.js": "/* © */\n\"use strict\";\n/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */function myFunction(n,o){return n+o}console.log(\"myJS\");",
 		"my/ui/lib/my.view.xml": "<my>XML</my>\n",
 		"my/ui/lib/myHtmlPre.view.xml": "<my>XML</my>\n<!-- A comment in XML is the same as in HTML -->\n<html:pre>   </html:pre>",
 		"my/ui/lib/foo.properties": "FOO=BAR\n"

--- a/test/preload/expected/library_compat_154/my/ui/lib/library-preload.js
+++ b/test/preload/expected/library_compat_154/my/ui/lib/library-preload.js
@@ -1,6 +1,6 @@
 sap.ui.require.preload({
 	"my/ui/lib/library.js": "jQuery.sap.require(\"sap.ui.core.library\"),jQuery.sap.declare(\"my.ui.lib.library\"),sap.ui.getCore().initLibrary({name:\"my.ui.lib\",version:\"0.0.0\",dependencies:[\"sap.ui.core\"]});",
-	"my/ui/lib/myJS.js": "/* © */\n\"use strict\";function myFunction(n,o){return n+o}/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */\nconsole.log(\"myJS\");",
+	"my/ui/lib/myJS.js": "/* © */\n\"use strict\";\n/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */function myFunction(n,o){return n+o}console.log(\"myJS\");",
 	"my/ui/lib/my.view.xml": "<my>XML</my>\n",
 	"my/ui/lib/myHtmlPre.view.xml": "<my>XML</my>\n<!-- A comment in XML is the same as in HTML -->\n<html:pre>   </html:pre>",
 	"my/ui/lib/foo.properties": "FOO=BAR\n"

--- a/test/preload/expected/library_custom_uglify_params/my/ui/lib/library-preload.js
+++ b/test/preload/expected/library_custom_uglify_params/my/ui/lib/library-preload.js
@@ -1,6 +1,6 @@
 sap.ui.require.preload({
 	"my/ui/lib/library.js": "jQuery.sap.require(\"sap.ui.core.library\"),jQuery.sap.declare(\"my.ui.lib.library\"),sap.ui.getCore().initLibrary({name:\"my.ui.lib\",version:\"0.0.0\",dependencies:[\"sap.ui.core\"]});",
-	"my/ui/lib/myJS.js": "/* © */\n\"use strict\";function myFunction(longVariableName,longerVariableName){return longVariableName+longerVariableName+\"\\u518d\\u6309\\u4e00\\u6b21\\u9000\\u51fa\\u4f19\\u62fc\"}/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */\nconsole.log(\"myJS\");",
+	"my/ui/lib/myJS.js": "/* © */\n\"use strict\";\n/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */function myFunction(longVariableName,longerVariableName){return longVariableName+longerVariableName+\"\\u518d\\u6309\\u4e00\\u6b21\\u9000\\u51fa\\u4f19\\u62fc\"}console.log(\"myJS\");",
 	"my/ui/lib/my.view.xml": "<my>XML</my>\n",
 	"my/ui/lib/myHtmlPre.view.xml": "<my>XML</my>\n<!-- A comment in XML is the same as in HTML -->\n<html:pre>   </html:pre>",
 	"my/ui/lib/foo.properties": "FOO=BAR\n"

--- a/test/preload/expected/library_default_options/my/ui/lib/library-preload.js
+++ b/test/preload/expected/library_default_options/my/ui/lib/library-preload.js
@@ -1,6 +1,6 @@
 sap.ui.require.preload({
 	"my/ui/lib/library.js": "jQuery.sap.require(\"sap.ui.core.library\"),jQuery.sap.declare(\"my.ui.lib.library\"),sap.ui.getCore().initLibrary({name:\"my.ui.lib\",version:\"0.0.0\",dependencies:[\"sap.ui.core\"]});",
-	"my/ui/lib/myJS.js": "/* © */\n\"use strict\";function myFunction(n,o){return n+o}/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */\nconsole.log(\"myJS\");",
+	"my/ui/lib/myJS.js": "/* © */\n\"use strict\";\n/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */function myFunction(n,o){return n+o}console.log(\"myJS\");",
 	"my/ui/lib/my.view.xml": "<my>XML</my>\n",
 	"my/ui/lib/myHtmlPre.view.xml": "<my>XML</my>\n<!-- A comment in XML is the same as in HTML -->\n<html:pre>   </html:pre>",
 	"my/ui/lib/foo.properties": "FOO=BAR\n"

--- a/test/preload/expected/library_resource_prefix/library-preload.js
+++ b/test/preload/expected/library_resource_prefix/library-preload.js
@@ -1,6 +1,6 @@
 sap.ui.require.preload({
 	"my/ui/lib/library.js": "jQuery.sap.require(\"sap.ui.core.library\"),jQuery.sap.declare(\"my.ui.lib.library\"),sap.ui.getCore().initLibrary({name:\"my.ui.lib\",version:\"0.0.0\",dependencies:[\"sap.ui.core\"]});",
-	"my/ui/lib/myJS.js": "/* © */\n\"use strict\";function myFunction(n,o){return n+o}/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */\nconsole.log(\"myJS\");",
+	"my/ui/lib/myJS.js": "/* © */\n\"use strict\";\n/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */function myFunction(n,o){return n+o}console.log(\"myJS\");",
 	"my/ui/lib/my.view.xml": "<my>XML</my>\n",
 	"my/ui/lib/myHtmlPre.view.xml": "<my>XML</my>\n<!-- A comment in XML is the same as in HTML -->\n<html:pre>   </html:pre>",
 	"my/ui/lib/foo.properties": "FOO=BAR\n"

--- a/test/preload/fixtures/app-same-dest/my/app/Component-preload.js
+++ b/test/preload/fixtures/app-same-dest/my/app/Component-preload.js
@@ -1,5 +1,5 @@
 sap.ui.require.preload({
-	"my/app/Component.js": "/* © */\n\"use strict\";function myFunction(n,o){return n+o}/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */\nconsole.log(\"myJS\");",
+	"my/app/Component.js": "/* © */\n\"use strict\";\n/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */function myFunction(n,o){return n+o}console.log(\"myJS\");",
 	"my/app/view/my.view.xml": "<my>XML</my>\n",
 	"my/app/view/myHtmlPre.view.xml": "<my>XML</my>\n<!-- A comment in XML is the same as in HTML -->\n<html:pre>   </html:pre>"
 }, "my/app/Component-preload");

--- a/test/preload/fixtures/library-same-dest/my/ui/lib/library-preload.js
+++ b/test/preload/fixtures/library-same-dest/my/ui/lib/library-preload.js
@@ -1,6 +1,6 @@
 sap.ui.require.preload({
 	"my/ui/lib/library.js": "jQuery.sap.require(\"sap.ui.core.library\"),jQuery.sap.declare(\"my.ui.lib.library\"),sap.ui.getCore().initLibrary({name:\"my.ui.lib\",version:\"0.0.0\",dependencies:[\"sap.ui.core\"]});",
-	"my/ui/lib/myJS.js": "/* © */\n\"use strict\";function myFunction(n,o){return n+o}/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */\nconsole.log(\"myJS\");",
+	"my/ui/lib/myJS.js": "/* © */\n\"use strict\";\n/**\n* This is a copyright comment\n*/\n/* (c) */\n/* released under */\n/* license */function myFunction(n,o){return n+o}console.log(\"myJS\");",
 	"my/ui/lib/my.view.xml": "<my>XML</my>\n",
 	"my/ui/lib/myHtmlPre.view.xml": "<my>XML</my>\n<!-- A comment in XML is the same as in HTML -->\n<html:pre>   </html:pre>",
 	"my/ui/lib/foo.properties": "FOO=BAR\n"


### PR DESCRIPTION
- Replacing uglify-js with uglify-es allows for ES6+ style JS code to be
minified in the preload-build process.

- "fromString" option has been removed as it is not available in
uglify-es.

Fixes https://github.com/SAP/grunt-openui5/issues/69