### PR TITLE
[INTERNAL] Prepare repository for release automation

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -2,8 +2,44 @@
 All notable changes to this project will be documented in this file.  
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-A list of unreleased changes can be found [here](https://github.com/SAP/grunt-openui5/compare/0.15.0...HEAD).
+{{ if .Versions -}}
+A list of unreleased changes can be found [here]({{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD).
+{{ end -}}
 
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }} [`{{ .Hash.Short }}`]({{ $.Info.RepositoryURL }}/commit/{{ .Hash.Long }})
+{{ end }}
+{{ end -}}
+
+{{- if .RevertCommits -}}
+### Reverts
+{{ range .RevertCommits -}}
+- {{ .Revert.Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{- if .Versions }}
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
 
 # 0.15.0 - 2018-10-16
 

--- a/.chglog/RELEASE.tpl.md
+++ b/.chglog/RELEASE.tpl.md
@@ -1,0 +1,33 @@
+{{ range .Versions }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }} [`{{ .Hash.Short }}`]({{ $.Info.RepositoryURL }}/commit/{{ .Hash.Long }})
+{{ end }}
+{{ end -}}
+
+{{- if .RevertCommits -}}
+### Reverts
+{{ range .RevertCommits -}}
+- {{ .Revert.Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+
+{{ if .Tag.Previous }}
+### All changes
+[`{{ .Tag.Previous.Name }}...{{ .Tag.Name }}`]
+{{ end }}
+
+{{ if .Tag.Previous -}}
+[`{{ .Tag.Previous.Name }}...{{ .Tag.Name }}`]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,33 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/SAP/grunt-openui5
+options:
+  commits:
+    filters:
+      Type:
+        - FEATURE
+        - FIX
+        - PERF
+        - DEPENDENCY
+        - BREAKING
+  commit_groups:
+    title_maps:
+       FEATURE: Features
+       FIX: Bug Fixes
+       PERF: Performance Improvements
+       DEPENDENCY: Dependency Updates
+       BREAKING: Breaking Changes
+  header:
+    pattern: "^\\[(\\w*)\\]\\s(?:([^\\:]*)\\:\\s)?(.*)$"
+    pattern_maps:
+      - Type
+      - Scope
+      - Subject
+  issues:
+    prefix:
+      - "#"
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/.chglog/release-config.yml
+++ b/.chglog/release-config.yml
@@ -1,0 +1,32 @@
+style: github
+template: RELEASE.tpl.md
+info:
+  repository_url: https://github.com/SAP/grunt-openui5
+options:
+  commits:
+    filters:
+      Type:
+        - FEATURE
+        - FIX
+        - PERF
+        - DEPENDENCY
+        - BREAKING
+  commit_groups:
+    title_maps:
+       FEATURE: Features
+       FIX: Bug Fixes
+       PERF: Performance Improvements
+       DEPENDENCY: Dependency Updates
+       BREAKING: Breaking Changes
+  header:
+    pattern: "^\\[(\\w*)\\]\\s(?:([^\\:]*)\\:\\s)?(.*)$"
+    pattern_maps:
+      - Type
+      - Scope
+      - Subject
+  issues:
+    prefix:
+      - "#"
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "version": "0.15.0",
   "description": "Grunt tasks around OpenUI5",
   "scripts": {
-    "test": "grunt"
+    "test": "grunt",
+    "preversion": "npm test",
+    "version": "git-chglog --next-tag v$npm_package_version -o CHANGELOG.md --tag-filter-pattern '^v' && git add CHANGELOG.md",
+    "postversion": "git push --follow-tags",
+    "release-note": "git-chglog -c .chglog/release-config.yml v$npm_package_version"
   },
   "files": [
     "tasks",


### PR DESCRIPTION
- Add changelog generation via [git-chglog](git-chglog/git-chglog)
  (needs to be installed separately)
- Changelog is generated starting with the upcoming version (0.16.0). Older changelog is used
as is
- Add npm scripts required by our release tool

See UI5 Tooling and karma-ui5 repositories for reference