### PR TITLE
[BREAKING] Require Node.js >= 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
 node_js:
+  - "14"
   - "12"
   - "10"
-  - "8"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "SAP SE",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">= 8.5"
+    "node": ">= 10"
   },
   "dependencies": {
     "async": "^3.2.0",


### PR DESCRIPTION
BREAKING CHANGE:
Support for older Node.js releases has been dropped.
Only Node.js v10 or higher is supported.