### PR TITLE
[INTERNAL] GitHub CI: Only check prod npm dependencies

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -57,7 +57,7 @@ jobs:
     - run: npm ci
       name: Install dependencies
 
-    - run: npm ls
+    - run: npm ls --prod
       name: Check for missing / extraneous Dependencies
 
     - run: npm run unit


### PR DESCRIPTION
Should resolve failures caused by missing peer-deps of devDependencies