### PR TITLE
Remove deprecated multiline dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2917,14 +2917,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 		},
-		"multiline": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/multiline/-/multiline-2.0.0.tgz",
-			"integrity": "sha512-+HpXaUcV8PIGNNmuhtlaVmw4NH0W30/A5WP+rq6pxZYBjDslX/sXkFgL3Mgk1cSGGIICjWu4gNStkJXL6ZM2DQ==",
-			"requires": {
-				"strip-indent": "^2.0.0"
-			}
-		},
 		"multimatch": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,18 @@
 			"requires": {
 				"@jridgewell/gen-mapping": "^0.1.0",
 				"@jridgewell/trace-mapping": "^0.3.9"
+			},
+			"dependencies": {
+				"@jridgewell/gen-mapping": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+					"integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+					"dev": true,
+					"requires": {
+						"@jridgewell/set-array": "^1.0.0",
+						"@jridgewell/sourcemap-codec": "^1.4.10"
+					}
+				}
 			}
 		},
 		"@babel/code-frame": {
@@ -30,21 +42,21 @@
 			"dev": true
 		},
 		"@babel/core": {
-			"version": "7.17.10",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.10.tgz",
-			"integrity": "sha512-liKoppandF3ZcBnIYFjfSDHZLKdLHGJRkoWtG8zQyGJBQfIYobpnVGI5+pLBNtS6psFLDzyq8+h5HiVljW9PNA==",
+			"version": "7.17.12",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.12.tgz",
+			"integrity": "sha512-44ODe6O1IVz9s2oJE3rZ4trNNKTX9O7KpQpfAP4t8QII/zwrVRHL7i2pxhqtcY7tqMLrrKfMlBKnm1QlrRFs5w==",
 			"dev": true,
 			"requires": {
 				"@ampproject/remapping": "^2.1.0",
 				"@babel/code-frame": "^7.16.7",
-				"@babel/generator": "^7.17.10",
+				"@babel/generator": "^7.17.12",
 				"@babel/helper-compilation-targets": "^7.17.10",
-				"@babel/helper-module-transforms": "^7.17.7",
+				"@babel/helper-module-transforms": "^7.17.12",
 				"@babel/helpers": "^7.17.9",
-				"@babel/parser": "^7.17.10",
+				"@babel/parser": "^7.17.12",
 				"@babel/template": "^7.16.7",
-				"@babel/traverse": "^7.17.10",
-				"@babel/types": "^7.17.10",
+				"@babel/traverse": "^7.17.12",
+				"@babel/types": "^7.17.12",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -53,9 +65,9 @@
 			},
 			"dependencies": {
 				"@babel/parser": {
-					"version": "7.17.10",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.10.tgz",
-					"integrity": "sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==",
+					"version": "7.17.12",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.12.tgz",
+					"integrity": "sha512-FLzHmN9V3AJIrWfOpvRlZCeVg/WLdicSnTMsLur6uDj9TT8ymUlG9XxURdW/XvuygK+2CW0poOJABdA4m/YKxA==",
 					"dev": true
 				},
 				"debug": {
@@ -82,13 +94,13 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.17.10",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.10.tgz",
-			"integrity": "sha512-46MJZZo9y3o4kmhBVc7zW7i8dtR1oIK/sdO5NcfcZRhTGYi+KKJRtHNgsU6c4VUcJmUNV/LQdebD/9Dlv4K+Tg==",
+			"version": "7.17.12",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.12.tgz",
+			"integrity": "sha512-V49KtZiiiLjH/CnIW6OjJdrenrGoyh6AmKQ3k2AZFKozC1h846Q4NYlZ5nqAigPDUXfGzC88+LOUuG8yKd2kCw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.17.10",
-				"@jridgewell/gen-mapping": "^0.1.0",
+				"@babel/types": "^7.17.12",
+				"@jridgewell/gen-mapping": "^0.3.0",
 				"jsesc": "^2.5.1"
 			}
 		},
@@ -150,9 +162,9 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.17.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
-			"integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
+			"version": "7.17.12",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.12.tgz",
+			"integrity": "sha512-t5s2BeSWIghhFRPh9XMn6EIGmvn8Lmw5RVASJzkIx1mSemubQQBNIZiQD7WzaFmaHIrjAec4x8z9Yx8SjJ1/LA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-environment-visitor": "^7.16.7",
@@ -161,8 +173,8 @@
 				"@babel/helper-split-export-declaration": "^7.16.7",
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"@babel/template": "^7.16.7",
-				"@babel/traverse": "^7.17.3",
-				"@babel/types": "^7.17.0"
+				"@babel/traverse": "^7.17.12",
+				"@babel/types": "^7.17.12"
 			}
 		},
 		"@babel/helper-simple-access": {
@@ -207,9 +219,9 @@
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.17.9",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
-			"integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
+			"version": "7.17.12",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
+			"integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.16.7",
@@ -287,35 +299,35 @@
 			},
 			"dependencies": {
 				"@babel/parser": {
-					"version": "7.17.10",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.10.tgz",
-					"integrity": "sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==",
+					"version": "7.17.12",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.12.tgz",
+					"integrity": "sha512-FLzHmN9V3AJIrWfOpvRlZCeVg/WLdicSnTMsLur6uDj9TT8ymUlG9XxURdW/XvuygK+2CW0poOJABdA4m/YKxA==",
 					"dev": true
 				}
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.17.10",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.10.tgz",
-			"integrity": "sha512-VmbrTHQteIdUUQNTb+zE12SHS/xQVIShmBPhlNP12hD5poF2pbITW1Z4172d03HegaQWhLffdkRJYtAzp0AGcw==",
+			"version": "7.17.12",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.12.tgz",
+			"integrity": "sha512-zULPs+TbCvOkIFd4FrG53xrpxvCBwLIgo6tO0tJorY7YV2IWFxUfS/lXDJbGgfyYt9ery/Gxj2niwttNnB0gIw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.16.7",
-				"@babel/generator": "^7.17.10",
+				"@babel/generator": "^7.17.12",
 				"@babel/helper-environment-visitor": "^7.16.7",
 				"@babel/helper-function-name": "^7.17.9",
 				"@babel/helper-hoist-variables": "^7.16.7",
 				"@babel/helper-split-export-declaration": "^7.16.7",
-				"@babel/parser": "^7.17.10",
-				"@babel/types": "^7.17.10",
+				"@babel/parser": "^7.17.12",
+				"@babel/types": "^7.17.12",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
 			"dependencies": {
 				"@babel/parser": {
-					"version": "7.17.10",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.10.tgz",
-					"integrity": "sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==",
+					"version": "7.17.12",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.12.tgz",
+					"integrity": "sha512-FLzHmN9V3AJIrWfOpvRlZCeVg/WLdicSnTMsLur6uDj9TT8ymUlG9XxURdW/XvuygK+2CW0poOJABdA4m/YKxA==",
 					"dev": true
 				},
 				"debug": {
@@ -336,9 +348,9 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.17.10",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.10.tgz",
-			"integrity": "sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==",
+			"version": "7.17.12",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.12.tgz",
+			"integrity": "sha512-rH8i29wcZ6x9xjzI5ILHL/yZkbQnCERdHlogKuIb4PUr7do4iT8DPekrTbBLWTnRQm6U0GYABbTMSzijmEqlAg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.16.7",
@@ -499,13 +511,14 @@
 			"dev": true
 		},
 		"@jridgewell/gen-mapping": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
-			"integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
+			"integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/set-array": "^1.0.0",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.9"
 			}
 		},
 		"@jridgewell/resolve-uri": {
@@ -555,39 +568,39 @@
 			"dev": true
 		},
 		"@vue/compiler-core": {
-			"version": "3.2.33",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.33.tgz",
-			"integrity": "sha512-AAmr52ji3Zhk7IKIuigX2osWWsb2nQE5xsdFYjdnmtQ4gymmqXbjLvkSE174+fF3A3kstYrTgGkqgOEbsdLDpw==",
+			"version": "3.2.34",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.34.tgz",
+			"integrity": "sha512-Y53lv04ZhDfqflhk4yEgBZrCL1RipbxqmqJFfl1PRkjOzt0bvJpf1sCNN81QNfXohVwFGf+Hng2ztwLwOZgbuA==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.16.4",
-				"@vue/shared": "3.2.33",
+				"@vue/shared": "3.2.34",
 				"estree-walker": "^2.0.2",
 				"source-map": "^0.6.1"
 			}
 		},
 		"@vue/compiler-dom": {
-			"version": "3.2.33",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.33.tgz",
-			"integrity": "sha512-GhiG1C8X98Xz9QUX/RlA6/kgPBWJkjq0Rq6//5XTAGSYrTMBgcLpP9+CnlUg1TFxnnCVughAG+KZl28XJqw8uQ==",
+			"version": "3.2.34",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.34.tgz",
+			"integrity": "sha512-MFLUYDgy0aES9x1goU/pgxpzgT9IZOndO8qwQVSyVfUvl/CywEBtfBi5+8fsiBDhoGIT7g8qcsUUF1NYViU2vQ==",
 			"dev": true,
 			"requires": {
-				"@vue/compiler-core": "3.2.33",
-				"@vue/shared": "3.2.33"
+				"@vue/compiler-core": "3.2.34",
+				"@vue/shared": "3.2.34"
 			}
 		},
 		"@vue/compiler-sfc": {
-			"version": "3.2.33",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.33.tgz",
-			"integrity": "sha512-H8D0WqagCr295pQjUYyO8P3IejM3vEzeCO1apzByAEaAR/WimhMYczHfZVvlCE/9yBaEu/eu9RdiWr0kF8b71Q==",
+			"version": "3.2.34",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.34.tgz",
+			"integrity": "sha512-I+vT4soKJtdsoREBDYAcz56+yGpZ5T3GUigvBFgC2yTeTtBtREOPzYw8kZyMuD2ZlryPYBkbV8D9xxcvU0j/aw==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.16.4",
-				"@vue/compiler-core": "3.2.33",
-				"@vue/compiler-dom": "3.2.33",
-				"@vue/compiler-ssr": "3.2.33",
-				"@vue/reactivity-transform": "3.2.33",
-				"@vue/shared": "3.2.33",
+				"@vue/compiler-core": "3.2.34",
+				"@vue/compiler-dom": "3.2.34",
+				"@vue/compiler-ssr": "3.2.34",
+				"@vue/reactivity-transform": "3.2.34",
+				"@vue/shared": "3.2.34",
 				"estree-walker": "^2.0.2",
 				"magic-string": "^0.25.7",
 				"postcss": "^8.1.10",
@@ -595,32 +608,32 @@
 			}
 		},
 		"@vue/compiler-ssr": {
-			"version": "3.2.33",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.33.tgz",
-			"integrity": "sha512-XQh1Xdk3VquDpXsnoCd7JnMoWec9CfAzQDQsaMcSU79OrrO2PNR0ErlIjm/mGq3GmBfkQjzZACV+7GhfRB8xMQ==",
+			"version": "3.2.34",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.34.tgz",
+			"integrity": "sha512-zyaMdGJhxoA34ibWsXF7VH1PO5yrNB1MZg/ByRfXGM8JefGQaz+PpHvBy/5OI0ehEyhAyCb7279JdhYHacMZbw==",
 			"dev": true,
 			"requires": {
-				"@vue/compiler-dom": "3.2.33",
-				"@vue/shared": "3.2.33"
+				"@vue/compiler-dom": "3.2.34",
+				"@vue/shared": "3.2.34"
 			}
 		},
 		"@vue/reactivity-transform": {
-			"version": "3.2.33",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.33.tgz",
-			"integrity": "sha512-4UL5KOIvSQb254aqenW4q34qMXbfZcmEsV/yVidLUgvwYQQ/D21bGX3DlgPUGI3c4C+iOnNmDCkIxkILoX/Pyw==",
+			"version": "3.2.34",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.34.tgz",
+			"integrity": "sha512-OtsrL4/i6Md279pMhZ8wRijeDhPSdnXrH9wmqAcKDhVcp1L2kSWlgVVLa1jGIyyFYE806YiJNJiGBvXPGXMzxw==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.16.4",
-				"@vue/compiler-core": "3.2.33",
-				"@vue/shared": "3.2.33",
+				"@vue/compiler-core": "3.2.34",
+				"@vue/shared": "3.2.34",
 				"estree-walker": "^2.0.2",
 				"magic-string": "^0.25.7"
 			}
 		},
 		"@vue/shared": {
-			"version": "3.2.33",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.33.tgz",
-			"integrity": "sha512-UBc1Pg1T3yZ97vsA2ueER0F6GbJebLHYlEi4ou1H5YL4KWvMOOWwpYo9/QpWq93wxKG6Wo13IY74Hcn/f7c7Bg==",
+			"version": "3.2.34",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.34.tgz",
+			"integrity": "sha512-zhEeB8TrFmTXmTXmu/wcjEhgrjO4xqdDQrCdPhjX7NxfoLqoBVKguOm8qyihWNLbP+41svYY4za9mqXyqFLzNg==",
 			"dev": true
 		},
 		"abbrev": {
@@ -673,9 +686,9 @@
 			}
 		},
 		"ansi-colors": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+			"integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
 			"dev": true
 		},
 		"ansi-regex": {
@@ -714,7 +727,7 @@
 		"archy": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-			"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+			"integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
 			"dev": true
 		},
 		"argparse": {
@@ -735,7 +748,7 @@
 		"array-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
-			"integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
+			"integrity": "sha512-zHjL5SZa68hkKHBFBK6DJCTtr9sfTCPCaph/L7tMSLcTFgy+zX7E+6q5UArbtOtMBCtxdICpfTCspRse+ywyXA==",
 			"dev": true
 		},
 		"array-slice": {
@@ -759,7 +772,7 @@
 		"assert": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+			"integrity": "sha512-N+aAxov+CKVS3JuhDIQFr24XvZvwE96Wlhk9dytTg/GmwWoghdOvR8dspx8MVz71O+Y0pA3UPqHF68D6iy8UvQ==",
 			"dev": true,
 			"requires": {
 				"util": "0.10.3"
@@ -804,7 +817,7 @@
 		"batch": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+			"integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
 			"dev": true
 		},
 		"binary-extensions": {
@@ -1798,9 +1811,9 @@
 			"dev": true
 		},
 		"glob": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.2.tgz",
-			"integrity": "sha512-NzDgHDiJwKYByLrL5lONmQFpK/2G78SMMfo+E9CuGlX4IkvfKDsiQSNPwAYxEy+e6p7ZQ3uslSLlwlJcqezBmQ==",
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -2779,6 +2792,12 @@
 				"yargs-unparser": "2.0.0"
 			},
 			"dependencies": {
+				"ansi-colors": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+					"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+					"dev": true
+				},
 				"argparse": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3474,12 +3493,12 @@
 			}
 		},
 		"postcss": {
-			"version": "8.4.13",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz",
-			"integrity": "sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==",
+			"version": "8.4.14",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+			"integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
 			"dev": true,
 			"requires": {
-				"nanoid": "^3.3.3",
+				"nanoid": "^3.3.4",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			}
@@ -3977,11 +3996,6 @@
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
 			"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
 			"dev": true
-		},
-		"strip-indent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
 		},
 		"strip-json-comments": {
 			"version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
 		"cors": "^2.8.5",
 		"less-openui5": "^0.11.2",
 		"maxmin": "^3.0.0",
-		"multiline": "^2.0.0",
 		"pretty-data": "^0.40.0",
 		"serve-static": "^1.15.0",
 		"slash": "^3.0.0",

--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -19,10 +19,10 @@ LiveReloadPluginLessCss.prototype.reload = function(path, options) {
 	// do only run this if less is not loaded (LiveReload LessPlugin will handle this)
 	if (!this.window.less) {
 		// reload stylesheets (css) also if a less file was changed
-		if (path.match(/.less$/i)) {
+		if (path.match(/\\.less$/i)) {
 			return this.window.LiveReload.reloader.reloadStylesheet(path);
 		}
-		if (options.originalPath.match(/.less$/i)) {
+		if (options.originalPath.match(/\\.less$/i)) {
 			return this.window.LiveReload.reloader.reloadStylesheet(options.originalPath);
 		}
 	}

--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -7,9 +7,8 @@ const serveStatic = require("serve-static");
 const inject = require("connect-inject");
 const cors = require("cors");
 const urljoin = require("urljoin");
-const multiline = require("multiline");
 
-const liveReloadLessCssPlugin = multiline(function() {/*
+const liveReloadLessCssPlugin = `
 var LiveReloadPluginLessCss = function(window, host) {
 	this.window = window;
 	this.host = host;
@@ -20,10 +19,10 @@ LiveReloadPluginLessCss.prototype.reload = function(path, options) {
 	// do only run this if less is not loaded (LiveReload LessPlugin will handle this)
 	if (!this.window.less) {
 		// reload stylesheets (css) also if a less file was changed
-		if (path.match(/\.less$/i)) {
+		if (path.match(/.less$/i)) {
 			return this.window.LiveReload.reloader.reloadStylesheet(path);
 		}
-		if (options.originalPath.match(/\.less$/i)) {
+		if (options.originalPath.match(/.less$/i)) {
 			return this.window.LiveReload.reloader.reloadStylesheet(options.originalPath);
 		}
 	}
@@ -35,7 +34,7 @@ LiveReloadPluginLessCss.prototype.analyze = function() {
 		disable: (this.window.less && this.window.less.refresh)
 	};
 };
-*/});
+`;
 
 module.exports = function(grunt, config) {
 	grunt.registerMultiTask("openui5_connect", "Grunt task to start an OpenUI5 connect server", function() {

--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -33,8 +33,7 @@ LiveReloadPluginLessCss.prototype.analyze = function() {
 	return {
 		disable: (this.window.less && this.window.less.refresh)
 	};
-};
-`;
+};`;
 
 module.exports = function(grunt, config) {
 	grunt.registerMultiTask("openui5_connect", "Grunt task to start an OpenUI5 connect server", function() {


### PR DESCRIPTION
The dependency had some use pre es 2015 but is not required since then
and the author has deprecated it 4 years ago.

See issue https://github.com/SAP/grunt-openui5/issues/234